### PR TITLE
Update optimize_mythdb.pl

### DIFF
--- a/mythtv/contrib/maintenance/optimize_mythdb.pl
+++ b/mythtv/contrib/maintenance/optimize_mythdb.pl
@@ -46,4 +46,8 @@
     if ($dbh->do("ALTER TABLE `filemarkup` ORDER BY filename")) {
         print "Defragmented: filemarkup\n";
     }
+# Remove deletependings
+   if ($dbh->do("UPDATE recorded SET deletepending = 0 where recgroup = 'Deleted';")) {
+       print "Fixed deletependings\n";
+   }
 


### PR DESCRIPTION
Mythtv can leave recordings in the 'deletepending' state if system closedown occurs shortly after deletion.  In a mythwelcome scenario this can leave hundreds of these files.  This change removes that flag allowing backend to delete both the files and their database entry.

Thank you for contributing to MythTV!

Please review the checklist below to ensure that your contribution
to MythTV is ready for review by our developers.

It is helpful to regularly rebase your pull request to ensure changes
apply cleanly to the current MythTV development branch.

##### Checklist
<!-- Remove items that do not apply. For completed items, change [ ] to [x]. -->

- [x] contribution does not duplicate one of our [existing pull requests](https://github.com/MythTV/mythtv/pulls)
- [x] contribution is in a branch rebased against [master](https://github.com/MythTV/mythtv)
- [x] code compiles successfully without errors
- [x] code follows the [MythTV Coding Standards](https://www.mythtv.org/wiki/Coding_Standards)
- [x] documentation added/updated/removed where necessary
- [x] commits are logically organised and have [good commit messages](https://chris.beams.io/posts/git-commit)

